### PR TITLE
Generate types with the correct child names

### DIFF
--- a/src/geoarrow/schema.c
+++ b/src/geoarrow/schema.c
@@ -22,17 +22,29 @@ static GeoArrowErrorCode GeoArrowSchemaInitCoordStruct(struct ArrowSchema* schem
 }
 
 static GeoArrowErrorCode GeoArrowSchemaInitListStruct(struct ArrowSchema* schema,
-                                                      const char* dims, int n) {
+                                                      const char* dims, int n,
+                                                      const char** child_names) {
   if (n == 0) {
     return GeoArrowSchemaInitCoordStruct(schema, dims);
   } else {
     NANOARROW_RETURN_NOT_OK(ArrowSchemaInit(schema, NANOARROW_TYPE_LIST));
     NANOARROW_RETURN_NOT_OK(ArrowSchemaAllocateChildren(schema, 1));
     NANOARROW_RETURN_NOT_OK(
-        GeoArrowSchemaInitListStruct(schema->children[0], dims, n - 1));
-    return ArrowSchemaSetName(schema->children[0], "item");
+        GeoArrowSchemaInitListStruct(schema->children[0], dims, n - 1, child_names + 1));
+    return ArrowSchemaSetName(schema->children[0], child_names[0]);
   }
 }
+
+#define CHILD_NAMES_LINESTRING \
+  (const char*[]) { "vertices" }
+#define CHILD_NAMES_POLYGON \
+  (const char*[]) { "rings", "vertices" }
+#define CHILD_NAMES_MULTIPOINT \
+  (const char*[]) { "points" }
+#define CHILD_NAMES_MULTILINESTRING \
+  (const char*[]) { "linestrings", "vertices" }
+#define CHILD_NAMES_MULTIPOLYGON \
+  (const char*[]) { "polygons", "rings", "vertices" }
 
 GeoArrowErrorCode GeoArrowSchemaInit(struct ArrowSchema* schema, enum GeoArrowType type) {
   schema->release = NULL;
@@ -46,46 +58,54 @@ GeoArrowErrorCode GeoArrowSchemaInit(struct ArrowSchema* schema, enum GeoArrowTy
     case GEOARROW_TYPE_POINT:
       return GeoArrowSchemaInitCoordStruct(schema, "xy");
     case GEOARROW_TYPE_LINESTRING:
+      return GeoArrowSchemaInitListStruct(schema, "xy", 1, CHILD_NAMES_LINESTRING);
     case GEOARROW_TYPE_MULTIPOINT:
-      return GeoArrowSchemaInitListStruct(schema, "xy", 1);
+      return GeoArrowSchemaInitListStruct(schema, "xy", 1, CHILD_NAMES_MULTIPOINT);
     case GEOARROW_TYPE_POLYGON:
+      return GeoArrowSchemaInitListStruct(schema, "xy", 2, CHILD_NAMES_POLYGON);
     case GEOARROW_TYPE_MULTILINESTRING:
-      return GeoArrowSchemaInitListStruct(schema, "xy", 2);
+      return GeoArrowSchemaInitListStruct(schema, "xy", 2, CHILD_NAMES_MULTILINESTRING);
     case GEOARROW_TYPE_MULTIPOLYGON:
-      return GeoArrowSchemaInitListStruct(schema, "xy", 3);
+      return GeoArrowSchemaInitListStruct(schema, "xy", 3, CHILD_NAMES_MULTIPOLYGON);
 
     case GEOARROW_TYPE_POINT_Z:
       return GeoArrowSchemaInitCoordStruct(schema, "xyz");
     case GEOARROW_TYPE_LINESTRING_Z:
+      return GeoArrowSchemaInitListStruct(schema, "xyz", 1, CHILD_NAMES_LINESTRING);
     case GEOARROW_TYPE_MULTIPOINT_Z:
-      return GeoArrowSchemaInitListStruct(schema, "xyz", 1);
+      return GeoArrowSchemaInitListStruct(schema, "xyz", 1, CHILD_NAMES_MULTIPOINT);
     case GEOARROW_TYPE_POLYGON_Z:
+      return GeoArrowSchemaInitListStruct(schema, "xyz", 2, CHILD_NAMES_POLYGON);
     case GEOARROW_TYPE_MULTILINESTRING_Z:
-      return GeoArrowSchemaInitListStruct(schema, "xyz", 2);
+      return GeoArrowSchemaInitListStruct(schema, "xyz", 2, CHILD_NAMES_MULTILINESTRING);
     case GEOARROW_TYPE_MULTIPOLYGON_Z:
-      return GeoArrowSchemaInitListStruct(schema, "xyz", 3);
+      return GeoArrowSchemaInitListStruct(schema, "xyz", 3, CHILD_NAMES_MULTIPOLYGON);
 
     case GEOARROW_TYPE_POINT_M:
       return GeoArrowSchemaInitCoordStruct(schema, "xym");
     case GEOARROW_TYPE_LINESTRING_M:
+      return GeoArrowSchemaInitListStruct(schema, "xym", 1, CHILD_NAMES_LINESTRING);
     case GEOARROW_TYPE_MULTIPOINT_M:
-      return GeoArrowSchemaInitListStruct(schema, "xym", 1);
+      return GeoArrowSchemaInitListStruct(schema, "xym", 1, CHILD_NAMES_MULTIPOINT);
     case GEOARROW_TYPE_POLYGON_M:
+      return GeoArrowSchemaInitListStruct(schema, "xym", 2, CHILD_NAMES_POLYGON);
     case GEOARROW_TYPE_MULTILINESTRING_M:
-      return GeoArrowSchemaInitListStruct(schema, "xym", 2);
+      return GeoArrowSchemaInitListStruct(schema, "xym", 2, CHILD_NAMES_MULTILINESTRING);
     case GEOARROW_TYPE_MULTIPOLYGON_M:
-      return GeoArrowSchemaInitListStruct(schema, "xym", 3);
+      return GeoArrowSchemaInitListStruct(schema, "xym", 3, CHILD_NAMES_MULTIPOLYGON);
 
     case GEOARROW_TYPE_POINT_ZM:
       return GeoArrowSchemaInitCoordStruct(schema, "xyzm");
     case GEOARROW_TYPE_LINESTRING_ZM:
+      return GeoArrowSchemaInitListStruct(schema, "xyzm", 1, CHILD_NAMES_LINESTRING);
     case GEOARROW_TYPE_MULTIPOINT_ZM:
-      return GeoArrowSchemaInitListStruct(schema, "xyzm", 1);
+      return GeoArrowSchemaInitListStruct(schema, "xyzm", 1, CHILD_NAMES_MULTIPOINT);
     case GEOARROW_TYPE_POLYGON_ZM:
+      return GeoArrowSchemaInitListStruct(schema, "xyzm", 2, CHILD_NAMES_POLYGON);
     case GEOARROW_TYPE_MULTILINESTRING_ZM:
-      return GeoArrowSchemaInitListStruct(schema, "xyzm", 2);
+      return GeoArrowSchemaInitListStruct(schema, "xyzm", 2, CHILD_NAMES_MULTILINESTRING);
     case GEOARROW_TYPE_MULTIPOLYGON_ZM:
-      return GeoArrowSchemaInitListStruct(schema, "xyzm", 3);
+      return GeoArrowSchemaInitListStruct(schema, "xyzm", 3, CHILD_NAMES_MULTIPOLYGON);
 
     default:
       break;

--- a/src/geoarrow/schema_test.cc
+++ b/src/geoarrow/schema_test.cc
@@ -256,22 +256,26 @@ TEST(SchemaTest, SchemaTestInitSchemaLinestring) {
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_LINESTRING), GEOARROW_OK);
   auto maybe_type = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type.status());
-  EXPECT_TRUE(maybe_type.ValueUnsafe()->Equals(list(coord_type("xy"))));
+  EXPECT_TRUE(
+      maybe_type.ValueUnsafe()->Equals(list(field("vertices", coord_type("xy")))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_LINESTRING_Z), GEOARROW_OK);
   auto maybe_type_z = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_z.status());
-  EXPECT_TRUE(maybe_type_z.ValueUnsafe()->Equals(list(coord_type("xyz"))));
+  EXPECT_TRUE(
+      maybe_type_z.ValueUnsafe()->Equals(list(field("vertices", coord_type("xyz")))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_LINESTRING_M), GEOARROW_OK);
   auto maybe_type_m = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_m.status());
-  EXPECT_TRUE(maybe_type_m.ValueUnsafe()->Equals(list(coord_type("xym"))));
+  EXPECT_TRUE(
+      maybe_type_m.ValueUnsafe()->Equals(list(field("vertices", coord_type("xym")))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_LINESTRING_ZM), GEOARROW_OK);
   auto maybe_type_zm = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_zm.status());
-  EXPECT_TRUE(maybe_type_zm.ValueUnsafe()->Equals(list(coord_type("xyzm"))));
+  EXPECT_TRUE(
+      maybe_type_zm.ValueUnsafe()->Equals(list(field("vertices", coord_type("xyzm")))));
 }
 
 TEST(SchemaTest, SchemaTestInitSchemaPolygon) {
@@ -280,22 +284,26 @@ TEST(SchemaTest, SchemaTestInitSchemaPolygon) {
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_POLYGON), GEOARROW_OK);
   auto maybe_type = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type.status());
-  EXPECT_TRUE(maybe_type.ValueUnsafe()->Equals(list(list(coord_type("xy")))));
+  EXPECT_TRUE(maybe_type.ValueUnsafe()->Equals(
+      list(field("rings", list(field("vertices", coord_type("xy")))))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_POLYGON_Z), GEOARROW_OK);
   auto maybe_type_z = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_z.status());
-  EXPECT_TRUE(maybe_type_z.ValueUnsafe()->Equals(list(list(coord_type("xyz")))));
+  EXPECT_TRUE(maybe_type_z.ValueUnsafe()->Equals(
+      list(field("rings", list(field("vertices", coord_type("xyz")))))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_POLYGON_M), GEOARROW_OK);
   auto maybe_type_m = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_m.status());
-  EXPECT_TRUE(maybe_type_m.ValueUnsafe()->Equals(list(list(coord_type("xym")))));
+  EXPECT_TRUE(maybe_type_m.ValueUnsafe()->Equals(
+      list(field("rings", list(field("vertices", coord_type("xym")))))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_POLYGON_ZM), GEOARROW_OK);
   auto maybe_type_zm = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_zm.status());
-  EXPECT_TRUE(maybe_type_zm.ValueUnsafe()->Equals(list(list(coord_type("xyzm")))));
+  EXPECT_TRUE(maybe_type_zm.ValueUnsafe()->Equals(
+      list(field("rings", list(field("vertices", coord_type("xyzm")))))));
 }
 
 TEST(SchemaTest, SchemaTestInitSchemaMultipoint) {
@@ -304,22 +312,25 @@ TEST(SchemaTest, SchemaTestInitSchemaMultipoint) {
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTIPOINT), GEOARROW_OK);
   auto maybe_type = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type.status());
-  EXPECT_TRUE(maybe_type.ValueUnsafe()->Equals(list(coord_type("xy"))));
+  EXPECT_TRUE(maybe_type.ValueUnsafe()->Equals(list(field("points", coord_type("xy")))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTIPOINT_Z), GEOARROW_OK);
   auto maybe_type_z = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_z.status());
-  EXPECT_TRUE(maybe_type_z.ValueUnsafe()->Equals(list(coord_type("xyz"))));
+  EXPECT_TRUE(
+      maybe_type_z.ValueUnsafe()->Equals(list(field("points", coord_type("xyz")))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTIPOINT_M), GEOARROW_OK);
   auto maybe_type_m = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_m.status());
-  EXPECT_TRUE(maybe_type_m.ValueUnsafe()->Equals(list(coord_type("xym"))));
+  EXPECT_TRUE(
+      maybe_type_m.ValueUnsafe()->Equals(list(field("points", coord_type("xym")))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTIPOINT_ZM), GEOARROW_OK);
   auto maybe_type_zm = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_zm.status());
-  EXPECT_TRUE(maybe_type_zm.ValueUnsafe()->Equals(list(coord_type("xyzm"))));
+  EXPECT_TRUE(
+      maybe_type_zm.ValueUnsafe()->Equals(list(field("points", coord_type("xyzm")))));
 }
 
 TEST(SchemaTest, SchemaTestInitSchemaMultilinestring) {
@@ -328,22 +339,26 @@ TEST(SchemaTest, SchemaTestInitSchemaMultilinestring) {
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTILINESTRING), GEOARROW_OK);
   auto maybe_type = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type.status());
-  EXPECT_TRUE(maybe_type.ValueUnsafe()->Equals(list(list(coord_type("xy")))));
+  EXPECT_TRUE(maybe_type.ValueUnsafe()->Equals(
+      list(field("linestrings", list(field("vertices", coord_type("xy")))))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTILINESTRING_Z), GEOARROW_OK);
   auto maybe_type_z = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_z.status());
-  EXPECT_TRUE(maybe_type_z.ValueUnsafe()->Equals(list(list(coord_type("xyz")))));
+  EXPECT_TRUE(maybe_type_z.ValueUnsafe()->Equals(
+      list(field("linestrings", list(field("vertices", coord_type("xyz")))))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTILINESTRING_M), GEOARROW_OK);
   auto maybe_type_m = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_m.status());
-  EXPECT_TRUE(maybe_type_m.ValueUnsafe()->Equals(list(list(coord_type("xym")))));
+  EXPECT_TRUE(maybe_type_m.ValueUnsafe()->Equals(
+      list(field("linestrings", list(field("vertices", coord_type("xym")))))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTILINESTRING_ZM), GEOARROW_OK);
   auto maybe_type_zm = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_zm.status());
-  EXPECT_TRUE(maybe_type_zm.ValueUnsafe()->Equals(list(list(coord_type("xyzm")))));
+  EXPECT_TRUE(maybe_type_zm.ValueUnsafe()->Equals(
+      list(field("linestrings", list(field("vertices", coord_type("xyzm")))))));
 }
 
 TEST(SchemaTest, SchemaTestInitSchemaMultipolygon) {
@@ -352,20 +367,24 @@ TEST(SchemaTest, SchemaTestInitSchemaMultipolygon) {
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTIPOLYGON), GEOARROW_OK);
   auto maybe_type = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type.status());
-  EXPECT_TRUE(maybe_type.ValueUnsafe()->Equals(list(list(list(coord_type("xy"))))));
+  EXPECT_TRUE(maybe_type.ValueUnsafe()->Equals(list(field(
+      "polygons", list(field("rings", list(field("vertices", coord_type("xy")))))))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTIPOLYGON_Z), GEOARROW_OK);
   auto maybe_type_z = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_z.status());
-  EXPECT_TRUE(maybe_type_z.ValueUnsafe()->Equals(list(list(list(coord_type("xyz"))))));
+  EXPECT_TRUE(maybe_type_z.ValueUnsafe()->Equals(list(field(
+      "polygons", list(field("rings", list(field("vertices", coord_type("xyz")))))))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTIPOLYGON_M), GEOARROW_OK);
   auto maybe_type_m = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_m.status());
-  EXPECT_TRUE(maybe_type_m.ValueUnsafe()->Equals(list(list(list(coord_type("xym"))))));
+  EXPECT_TRUE(maybe_type_m.ValueUnsafe()->Equals(list(field(
+      "polygons", list(field("rings", list(field("vertices", coord_type("xym")))))))));
 
   EXPECT_EQ(GeoArrowSchemaInit(&schema, GEOARROW_TYPE_MULTIPOLYGON_ZM), GEOARROW_OK);
   auto maybe_type_zm = ImportType(&schema);
   ASSERT_ARROW_OK(maybe_type_zm.status());
-  EXPECT_TRUE(maybe_type_zm.ValueUnsafe()->Equals(list(list(list(coord_type("xyzm"))))));
+  EXPECT_TRUE(maybe_type_zm.ValueUnsafe()->Equals(list(field(
+      "polygons", list(field("rings", list(field("vertices", coord_type("xyzm")))))))));
 }


### PR DESCRIPTION
Inspired by https://github.com/geoarrow/geoarrow/pull/30 and https://github.com/geoarrow/geoarrow/pull/31, since I realized I was generating incorrect names!