### PR TITLE
Support max_element_size_bytes in wkt writer

### DIFF
--- a/python/geoarrow/pyarrow.py
+++ b/python/geoarrow/pyarrow.py
@@ -93,9 +93,9 @@ class VectorArray(pa.ExtensionArray):
             tail = self[:0]
 
         try:
-            kernel = Kernel.as_wkt(self.type)
-            head = kernel.push(head).storage
-            tail = kernel.push(tail).storage
+            kernel = Kernel.format_wkt(self.type, max_element_size_bytes=max_width)
+            head = kernel.push(head)
+            tail = kernel.push(tail)
         except Exception as e:
             err = f'* 1 or more display values failed to parse\n* {str(e)}'
             type_name = type(self).__name__

--- a/python/geoarrow/pyarrow.py
+++ b/python/geoarrow/pyarrow.py
@@ -635,6 +635,15 @@ class Kernel:
         return Kernel('as_wkb', type_in)
 
     @staticmethod
+    def format_wkt(type_in, significant_digits=None, max_element_size_bytes=None):
+        return Kernel(
+            'format_wkt',
+            type_in,
+            significant_digits=significant_digits,
+            max_element_size_bytes=max_element_size_bytes
+        )
+
+    @staticmethod
     def as_geoarrow(type_in, type_id):
         return Kernel('as_geoarrow', type_in, type=type_id)
 
@@ -643,6 +652,7 @@ class Kernel:
         if not options:
             return b''
 
+        options = {k: v for k, v in options.items() if v is not None}
         bytes = len(options).to_bytes(4, sys.byteorder, signed=True)
         for k, v in options.items():
             k = str(k)

--- a/python/tests/test_geoarrow_pyarrow.py
+++ b/python/tests/test_geoarrow_pyarrow.py
@@ -230,6 +230,18 @@ def test_kernel_as():
     assert out.type.crs == 'EPSG:1234'
     assert isinstance(out, ga.PointArray)
 
+def test_kernel_format():
+    array = ga.array(['POINT (30.12345 10.12345)'])
+    kernel = ga.Kernel.format_wkt(
+        array.type,
+        significant_digits=5,
+        max_element_size_bytes=15
+    )
+
+    out = kernel.push(array)
+    assert out.type == pa.string()
+    assert out[0].as_py() == 'POINT (30.123 1'
+
 def test_kernel_visit_void():
     array = ga.array(['POINT (30 10)'], ga.wkt())
     kernel = ga.Kernel.visit_void_agg(array.type)

--- a/src/geoarrow/geoarrow.h
+++ b/src/geoarrow/geoarrow.h
@@ -67,6 +67,7 @@ GeoArrowErrorCode GeoArrowKernelInit(struct GeoArrowKernel* kernel, const char* 
 struct GeoArrowWKTWriter {
   int significant_digits;
   int use_flat_multipoint;
+  int64_t max_element_size_bytes;
   void* private_data;
 };
 

--- a/src/geoarrow/kernel.c
+++ b/src/geoarrow/kernel.c
@@ -247,22 +247,15 @@ static int kernel_push_batch_geoarrow_by_feature(struct GeoArrowKernel* kernel,
       GeoArrowArrayViewSetArray(&private_data->array_view, array, error));
 
   private_data->v.error = error;
-  struct ArrowArrayView* array_view = &private_data->na_array_view;
 
   for (int64_t i = 0; i < array->length; i++) {
-    if (ArrowArrayViewIsNull(array_view, i)) {
-      NANOARROW_RETURN_NOT_OK(private_data->v.feat_start(&private_data->v));
-      NANOARROW_RETURN_NOT_OK(private_data->v.null_feat(&private_data->v));
-      NANOARROW_RETURN_NOT_OK(private_data->v.feat_end(&private_data->v));
-    } else {
-      int result =
-          GeoArrowArrayViewVisit(&private_data->array_view, i, 1, &private_data->v);
+    int result =
+        GeoArrowArrayViewVisit(&private_data->array_view, i, 1, &private_data->v);
 
-      if (result == EAGAIN) {
-        NANOARROW_RETURN_NOT_OK(private_data->v.feat_end(&private_data->v));
-      } else if (result != NANOARROW_OK) {
-        return result;
-      }
+    if (result == EAGAIN) {
+      NANOARROW_RETURN_NOT_OK(private_data->v.feat_end(&private_data->v));
+    } else if (result != NANOARROW_OK) {
+      return result;
     }
   }
 

--- a/src/geoarrow/kernel_test.cc
+++ b/src/geoarrow/kernel_test.cc
@@ -318,8 +318,62 @@ TEST(KernelTest, KernelTestFormatWKTFromWKB) {
   ASSERT_EQ(GeoArrowSchemaInitExtension(&schema_in, GEOARROW_TYPE_WKB), GEOARROW_OK);
   ASSERT_EQ(ArrowArrayInitFromSchema(&array_in, &schema_in, nullptr), GEOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array_in), GEOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendBytes(&array_in, data),
+  ASSERT_EQ(ArrowArrayAppendBytes(&array_in, data), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(&array_in, 1), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuilding(&array_in, nullptr), GEOARROW_OK);
+
+  struct ArrowBuffer buffer;
+  ASSERT_EQ(ArrowMetadataBuilderInit(&buffer, nullptr), GEOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(&buffer, ArrowCharView("max_element_size_bytes"),
+                                       ArrowCharView("10")),
             GEOARROW_OK);
+
+  EXPECT_EQ(GeoArrowKernelInit(&kernel, "format_wkt", nullptr), GEOARROW_OK);
+  EXPECT_EQ(kernel.start(&kernel, &schema_in, (char*)buffer.data, &schema_out, &error),
+            GEOARROW_OK);
+  EXPECT_STREQ(schema_out.format, "u");
+  EXPECT_EQ(kernel.push_batch(&kernel, &array_in, &array_out1, &error), GEOARROW_OK);
+  EXPECT_EQ(kernel.finish(&kernel, nullptr, &error), GEOARROW_OK);
+
+  kernel.release(&kernel);
+  EXPECT_EQ(kernel.release, nullptr);
+
+  EXPECT_EQ(array_out1.length, 2);
+  EXPECT_EQ(array_out1.null_count, 1);
+
+  struct ArrowArrayView array_view;
+  struct ArrowStringView item;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema_out, nullptr), GEOARROW_OK);
+
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array_out1, nullptr), GEOARROW_OK);
+  item = ArrowArrayViewGetStringUnsafe(&array_view, 0);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "POINT (30 ");
+  EXPECT_TRUE(ArrowArrayViewIsNull(&array_view, 1));
+
+  ArrowArrayViewReset(&array_view);
+  schema_in.release(&schema_in);
+  schema_out.release(&schema_out);
+  array_in.release(&array_in);
+  array_out1.release(&array_out1);
+  ArrowBufferReset(&buffer);
+}
+
+TEST(KernelTest, KernelTestFormatWKTFromGeoArrow) {
+  struct GeoArrowKernel kernel;
+  struct GeoArrowError error;
+
+  struct ArrowSchema schema_in;
+  struct ArrowSchema schema_out;
+  struct ArrowArray array_in;
+  struct ArrowArray array_out1;
+
+  ASSERT_EQ(GeoArrowSchemaInitExtension(&schema_in, GEOARROW_TYPE_POINT), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayInitFromSchema(&array_in, &schema_in, nullptr), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array_in), GEOARROW_OK);
+
+  ASSERT_EQ(ArrowArrayAppendInt(array_in.children[0], 30), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(array_in.children[1], 10), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishElement(&array_in), GEOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(&array_in, 1), GEOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuilding(&array_in, nullptr), GEOARROW_OK);
 

--- a/src/geoarrow/kernel_test.cc
+++ b/src/geoarrow/kernel_test.cc
@@ -239,6 +239,66 @@ TEST(KernelTest, KernelTestAsWKT) {
   array_out2.release(&array_out2);
 }
 
+TEST(KernelTest, KernelTestFormatWKT) {
+  struct GeoArrowKernel kernel;
+  struct GeoArrowError error;
+
+  struct ArrowSchema schema_in;
+  struct ArrowSchema schema_out;
+  struct ArrowArray array_in;
+  struct ArrowArray array_out1;
+
+  ASSERT_EQ(GeoArrowSchemaInitExtension(&schema_in, GEOARROW_TYPE_WKT), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayInitFromSchema(&array_in, &schema_in, nullptr), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array_in), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array_in, ArrowCharView("POINT (30.1234 10)")),
+            GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array_in, ArrowCharView("POINT (31.1234 11)")),
+            GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(&array_in, 1), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuilding(&array_in, nullptr), GEOARROW_OK);
+
+  struct ArrowBuffer buffer;
+  ASSERT_EQ(ArrowMetadataBuilderInit(&buffer, nullptr), GEOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(&buffer, ArrowCharView("significant_digits"),
+                                       ArrowCharView("3")),
+            GEOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(&buffer, ArrowCharView("max_element_size_bytes"),
+                                       ArrowCharView("14")),
+            GEOARROW_OK);
+
+  EXPECT_EQ(GeoArrowKernelInit(&kernel, "format_wkt", nullptr), GEOARROW_OK);
+  EXPECT_EQ(kernel.start(&kernel, &schema_in, (char*)buffer.data, &schema_out, &error),
+            GEOARROW_OK);
+  EXPECT_STREQ(schema_out.format, "u");
+  EXPECT_EQ(kernel.push_batch(&kernel, &array_in, &array_out1, &error), GEOARROW_OK);
+  EXPECT_EQ(kernel.finish(&kernel, nullptr, &error), GEOARROW_OK);
+
+  kernel.release(&kernel);
+  EXPECT_EQ(kernel.release, nullptr);
+
+  EXPECT_EQ(array_out1.length, 3);
+  EXPECT_EQ(array_out1.null_count, 1);
+
+  struct ArrowArrayView array_view;
+  struct ArrowStringView item;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema_out, nullptr), GEOARROW_OK);
+
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array_out1, nullptr), GEOARROW_OK);
+  item = ArrowArrayViewGetStringUnsafe(&array_view, 0);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "POINT (30.1 10");
+  item = ArrowArrayViewGetStringUnsafe(&array_view, 1);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "POINT (31.1 11");
+  EXPECT_TRUE(ArrowArrayViewIsNull(&array_view, 2));
+
+  ArrowArrayViewReset(&array_view);
+  schema_in.release(&schema_in);
+  schema_out.release(&schema_out);
+  array_in.release(&array_in);
+  array_out1.release(&array_out1);
+  ArrowBufferReset(&buffer);
+}
+
 TEST(KernelTest, KernelTestAsWKB) {
   struct GeoArrowKernel kernel;
   struct GeoArrowError error;

--- a/src/geoarrow/kernel_test.cc
+++ b/src/geoarrow/kernel_test.cc
@@ -239,7 +239,7 @@ TEST(KernelTest, KernelTestAsWKT) {
   array_out2.release(&array_out2);
 }
 
-TEST(KernelTest, KernelTestFormatWKT) {
+TEST(KernelTest, KernelTestFormatWKTFromWKT) {
   struct GeoArrowKernel kernel;
   struct GeoArrowError error;
 
@@ -290,6 +290,66 @@ TEST(KernelTest, KernelTestFormatWKT) {
   item = ArrowArrayViewGetStringUnsafe(&array_view, 1);
   EXPECT_EQ(std::string(item.data, item.size_bytes), "POINT (31.1 11");
   EXPECT_TRUE(ArrowArrayViewIsNull(&array_view, 2));
+
+  ArrowArrayViewReset(&array_view);
+  schema_in.release(&schema_in);
+  schema_out.release(&schema_out);
+  array_in.release(&array_in);
+  array_out1.release(&array_out1);
+  ArrowBufferReset(&buffer);
+}
+
+TEST(KernelTest, KernelTestFormatWKTFromWKB) {
+  struct GeoArrowKernel kernel;
+  struct GeoArrowError error;
+
+  struct ArrowSchema schema_in;
+  struct ArrowSchema schema_out;
+  struct ArrowArray array_in;
+  struct ArrowArray array_out1;
+
+  std::basic_string<uint8_t> point({0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00, 0x3e, 0x40, 0x00,
+                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x24, 0x40});
+  struct ArrowBufferView data;
+  data.data.data = point.data();
+  data.size_bytes = point.size();
+
+  ASSERT_EQ(GeoArrowSchemaInitExtension(&schema_in, GEOARROW_TYPE_WKB), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayInitFromSchema(&array_in, &schema_in, nullptr), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array_in), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendBytes(&array_in, data),
+            GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(&array_in, 1), GEOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuilding(&array_in, nullptr), GEOARROW_OK);
+
+  struct ArrowBuffer buffer;
+  ASSERT_EQ(ArrowMetadataBuilderInit(&buffer, nullptr), GEOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(&buffer, ArrowCharView("max_element_size_bytes"),
+                                       ArrowCharView("10")),
+            GEOARROW_OK);
+
+  EXPECT_EQ(GeoArrowKernelInit(&kernel, "format_wkt", nullptr), GEOARROW_OK);
+  EXPECT_EQ(kernel.start(&kernel, &schema_in, (char*)buffer.data, &schema_out, &error),
+            GEOARROW_OK);
+  EXPECT_STREQ(schema_out.format, "u");
+  EXPECT_EQ(kernel.push_batch(&kernel, &array_in, &array_out1, &error), GEOARROW_OK);
+  EXPECT_EQ(kernel.finish(&kernel, nullptr, &error), GEOARROW_OK);
+
+  kernel.release(&kernel);
+  EXPECT_EQ(kernel.release, nullptr);
+
+  EXPECT_EQ(array_out1.length, 2);
+  EXPECT_EQ(array_out1.null_count, 1);
+
+  struct ArrowArrayView array_view;
+  struct ArrowStringView item;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema_out, nullptr), GEOARROW_OK);
+
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array_out1, nullptr), GEOARROW_OK);
+  item = ArrowArrayViewGetStringUnsafe(&array_view, 0);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "POINT (30 ");
+  EXPECT_TRUE(ArrowArrayViewIsNull(&array_view, 1));
 
   ArrowArrayViewReset(&array_view);
   schema_in.release(&schema_in);

--- a/src/geoarrow/wkt_writer.c
+++ b/src/geoarrow/wkt_writer.c
@@ -30,6 +30,7 @@ struct WKTWriterPrivate {
   int64_t null_count;
   int significant_digits;
   int use_flat_multipoint;
+  int64_t max_element_size_bytes;
   int feat_is_null;
 };
 
@@ -154,6 +155,12 @@ static int coords_wkt(struct GeoArrowVisitor* v, const struct GeoArrowCoordView*
                              (n_coords * (n_dims - 1)) +  // spaces between ordinates
                              ((private->significant_digits + 1 + 5) * n_coords *
                               n_dims);  // significant digits + decimal + exponent
+  if (private->max_element_size_bytes >= 0 &&
+      max_chars_needed > private->max_element_size_bytes) {
+    // Because we write a coordinate before actually checking
+    max_chars_needed = private->max_element_size_bytes + 1024;
+  }
+
   NANOARROW_RETURN_NOT_OK(ArrowBufferReserve(&private->values, max_chars_needed));
 
   // Write the first coordinate, possibly with a leading comma if there was
@@ -176,6 +183,11 @@ static int coords_wkt(struct GeoArrowVisitor* v, const struct GeoArrowCoordView*
 
   // Write the remaining coordinates (which all have leading commas)
   for (int64_t i = 1; i < n_coords; i++) {
+    if (private->max_element_size_bytes >= 0 &&
+        private->values.size_bytes >= private->max_element_size_bytes) {
+      return EQFULL;
+    }
+
     ArrowBufferAppendUnsafe(&private->values, ", ", 2);
     WKTWriterWriteDoubleUnsafe(private, coords->values[0][i * coords->coords_stride]);
     for (int32_t j = 1; j < n_dims; j++) {
@@ -254,6 +266,8 @@ GeoArrowErrorCode GeoArrowWKTWriterInit(struct GeoArrowWKTWriter* writer) {
   private->significant_digits = 16;
   writer->use_flat_multipoint = 1;
   private->use_flat_multipoint = 1;
+  writer->max_element_size_bytes = -1;
+  private->max_element_size_bytes = -1;
   writer->private_data = private;
 
   return GEOARROW_OK;
@@ -266,6 +280,7 @@ void GeoArrowWKTWriterInitVisitor(struct GeoArrowWKTWriter* writer,
   struct WKTWriterPrivate* private = (struct WKTWriterPrivate*)writer->private_data;
   private->significant_digits = writer->significant_digits;
   private->use_flat_multipoint = writer->use_flat_multipoint;
+  private->max_element_size_bytes = writer->max_element_size_bytes;
 
   v->private_data = writer->private_data;
   v->feat_start = &feat_start_wkt;

--- a/src/geoarrow/wkt_writer_test.cc
+++ b/src/geoarrow/wkt_writer_test.cc
@@ -733,7 +733,7 @@ TEST(WKTWriterTest, WKTWriterTestMaxFeatLen) {
   struct GeoArrowWKTWriter writer;
   struct GeoArrowVisitor v;
   GeoArrowWKTWriterInit(&writer);
-  writer.max_element_size_bytes = 0;
+  writer.max_element_size_bytes = 6;
   GeoArrowWKTWriterInitVisitor(&writer, &v);
 
   TestCoords coords({1, 2}, {2, 3});
@@ -741,14 +741,14 @@ TEST(WKTWriterTest, WKTWriterTestMaxFeatLen) {
   EXPECT_EQ(v.feat_start(&v), GEOARROW_OK);
   EXPECT_EQ(v.geom_start(&v, GEOARROW_GEOMETRY_TYPE_LINESTRING, GEOARROW_DIMENSIONS_XY),
             GEOARROW_OK);
-  EXPECT_EQ(v.coords(&v, coords.view()), EQFULL);
+  EXPECT_EQ(v.coords(&v, coords.view()), EAGAIN);
   EXPECT_EQ(v.feat_end(&v), GEOARROW_OK);
 
   // Make sure we can try again with another feature
   EXPECT_EQ(v.feat_start(&v), GEOARROW_OK);
   EXPECT_EQ(v.geom_start(&v, GEOARROW_GEOMETRY_TYPE_LINESTRING, GEOARROW_DIMENSIONS_XY),
             GEOARROW_OK);
-  EXPECT_EQ(v.coords(&v, coords.view()), EQFULL);
+  EXPECT_EQ(v.coords(&v, coords.view()), EAGAIN);
   EXPECT_EQ(v.feat_end(&v), GEOARROW_OK);
 
   struct ArrowArray array;
@@ -761,10 +761,10 @@ TEST(WKTWriterTest, WKTWriterTestMaxFeatLen) {
   ArrowArrayViewSetArray(&view, &array, nullptr);
 
   struct ArrowStringView value = ArrowArrayViewGetStringUnsafe(&view, 0);
-  EXPECT_EQ(std::string(value.data, value.size_bytes), "LINESTRING (1 2");
+  EXPECT_EQ(std::string(value.data, value.size_bytes), "LINEST");
 
   value = ArrowArrayViewGetStringUnsafe(&view, 1);
-  EXPECT_EQ(std::string(value.data, value.size_bytes), "LINESTRING (1 2");
+  EXPECT_EQ(std::string(value.data, value.size_bytes), "LINEST");
 
   ArrowArrayViewReset(&view);
   array.release(&array);


### PR DESCRIPTION
To avoid hanging whist printing very large geometries.